### PR TITLE
chore: update opennextversion

### DIFF
--- a/.changeset/serious-plums-try.md
+++ b/.changeset/serious-plums-try.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+NextjsSite: update OpenNext version

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -31,14 +31,15 @@ import {
   SsrSiteNormalizedProps,
   SsrSiteProps,
 } from "./SsrSite.js";
+import { getOpenNextPackage } from "./util/compareSemver.js";
 import { Size, toCdkSize } from "./util/size.js";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
 import { VisibleError } from "../error.js";
-import { CachePolicyProps } from "aws-cdk-lib/aws-cloudfront";
 import { SsrFunction } from "./SsrFunction.js";
 import { Logger } from "../logger.js";
+
 type BaseFunction = {
   handler: string;
   bundle: string;
@@ -177,7 +178,7 @@ export interface NextjsSiteProps extends Omit<SsrSiteProps, "nodejs"> {
   };
 }
 
-const DEFAULT_OPEN_NEXT_VERSION = "3.0.2";
+const DEFAULT_OPEN_NEXT_VERSION = "3.1.6";
 
 type NextjsSiteNormalizedProps = NextjsSiteProps & SsrSiteNormalizedProps;
 
@@ -216,11 +217,13 @@ export class NextjsSite extends SsrSite {
   private openNextOutput?: OpenNextOutput;
 
   constructor(scope: Construct, id: string, props: NextjsSiteProps = {}) {
+    const openNextVersion = props.openNextVersion ?? DEFAULT_OPEN_NEXT_VERSION;
+
     super(scope, id, {
       buildCommand: [
         "npx",
         "--yes",
-        `open-next@${props?.openNextVersion ?? DEFAULT_OPEN_NEXT_VERSION}`,
+        `${getOpenNextPackage(openNextVersion)}@${openNextVersion}`,
         "build",
       ].join(" "),
       ...props,

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -31,7 +31,7 @@ import {
   SsrSiteNormalizedProps,
   SsrSiteProps,
 } from "./SsrSite.js";
-import { getOpenNextPackage } from "./util/compareSemver.js";
+import { compareSemver } from "./util/compareSemver.js";
 import { Size, toCdkSize } from "./util/size.js";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
@@ -218,12 +218,15 @@ export class NextjsSite extends SsrSite {
 
   constructor(scope: Construct, id: string, props: NextjsSiteProps = {}) {
     const openNextVersion = props.openNextVersion ?? DEFAULT_OPEN_NEXT_VERSION;
-
     super(scope, id, {
       buildCommand: [
         "npx",
         "--yes",
-        `${getOpenNextPackage(openNextVersion)}@${openNextVersion}`,
+        `${
+          compareSemver(openNextVersion, "3.1.3") <= 0
+            ? "open-next"
+            : "@opennextjs/aws"
+        }@${openNextVersion}`,
         "build",
       ].join(" "),
       ...props,

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -178,7 +178,7 @@ export interface NextjsSiteProps extends Omit<SsrSiteProps, "nodejs"> {
   };
 }
 
-const DEFAULT_OPEN_NEXT_VERSION = "3.1.6";
+const DEFAULT_OPEN_NEXT_VERSION = "3.2.2";
 
 type NextjsSiteNormalizedProps = NextjsSiteProps & SsrSiteNormalizedProps;
 

--- a/packages/sst/src/constructs/util/compareSemver.ts
+++ b/packages/sst/src/constructs/util/compareSemver.ts
@@ -1,4 +1,4 @@
-function compareSemver(v1: string, v2: string): number {
+export function compareSemver(v1: string, v2: string): number {
   if (v1 === "latest") return 1;
   if (/^[^\d]/.test(v1)) {
     v1 = v1.substring(1);
@@ -12,8 +12,4 @@ function compareSemver(v1: string, v2: string): number {
   if (major1 !== major2) return major1 - major2;
   if (minor1 !== minor2) return minor1 - minor2;
   return patch1 - patch2;
-}
-
-export function getOpenNextPackage(openNextVersion: string): string {
-  return compareSemver(openNextVersion, "3.1.3") <= 0 ? "open-next" : "@opennextjs/aws";
 }

--- a/packages/sst/src/constructs/util/compareSemver.ts
+++ b/packages/sst/src/constructs/util/compareSemver.ts
@@ -1,0 +1,19 @@
+function compareSemver(v1: string, v2: string): number {
+  if (v1 === "latest") return 1;
+  if (/^[^\d]/.test(v1)) {
+    v1 = v1.substring(1);
+  }
+  if (/^[^\d]/.test(v2)) {
+    v2 = v2.substring(1);
+  }
+  const [major1, minor1, patch1] = v1.split(".").map(Number);
+  const [major2, minor2, patch2] = v2.split(".").map(Number);
+
+  if (major1 !== major2) return major1 - major2;
+  if (minor1 !== minor2) return minor1 - minor2;
+  return patch1 - patch2;
+}
+
+export function getOpenNextPackage(openNextVersion: string): string {
+  return compareSemver(openNextVersion, "3.1.3") <= 0 ? "open-next" : "@opennextjs/aws";
+}


### PR DESCRIPTION
This PR bumps the default OpenNext version to be the latest which is `3.1.6`. It also changes the build command to address that version > 3.1.3 needs to use the new package called: `@opennextjs/aws`. If its `3.1.3` or lower it will use the old `open-next` package.