### PR TITLE
[SvelteKitSite construct] Handle different basePath formats

### DIFF
--- a/.changeset/sour-trains-argue.md
+++ b/.changeset/sour-trains-argue.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+SvelteKitSite: Handle different basePath formats

--- a/packages/sst/src/constructs/SvelteKitSite.ts
+++ b/packages/sst/src/constructs/SvelteKitSite.ts
@@ -159,8 +159,8 @@ export class SvelteKitSite extends SsrSite {
               pattern: fs
                 .statSync(path.join(sitePath, clientDir, item))
                 .isDirectory()
-                ? `${basePath}${item}/*`
-                : `${basePath}${item}`,
+                ? path.join(basePath, item, "*")
+                : path.join(basePath, item),
               origin: "s3",
             } as const)
         ),


### PR DESCRIPTION
Following [docs](https://github.com/sst/v2/blob/master/www/docs/constructs/SvelteKitSite.about.md#configuring-base-path) can result in malformed Cloudfront behaviour. 

This fix ensures that the pattern is not malformed given the values

```
basePath: '/docs'
basePath: 'docs'
basePath: 'docs/'
```