### PR TITLE
Service: supports custom scaling rules

### DIFF
--- a/www/generate.mjs
+++ b/www/generate.mjs
@@ -79,6 +79,7 @@ const CDK_DOCS_MAP = {
   HttpLambdaResponseType: "aws_apigatewayv2_authorizers",
   HttpUserPoolAuthorizer: "aws_apigatewayv2_authorizers",
   WebSocketLambdaAuthorizer: "aws_apigatewayv2_authorizers",
+  ScalableTaskCount: "aws_ecs",
   ServerlessCluster: "aws_rds",
   IServerlessCluster: "aws_rds",
   Role: "aws_iam",


### PR DESCRIPTION
Issue: https://github.com/sst/v2/issues/6

Predefined rules are great for common use cases. 
However we might want to have the flexibility to define custom scaling rules.

So I'm thinking to have a function to allow defining custom scaling would good way to do it.