### PR TITLE
fix(create-sst): ensure SST is version locked to 2 in templates

### DIFF
--- a/packages/create-sst/bin/presets/base/monorepo/preset.mjs
+++ b/packages/create-sst/bin/presets/base/monorepo/preset.mjs
@@ -7,12 +7,12 @@ export default [
   }),
   extract(),
   install({
-    packages: ["vitest", "@types/node", "sst"],
+    packages: ["vitest", "@types/node", "sst@^2"],
     path: "packages/core",
     dev: true,
   }),
   install({
-    packages: ["@types/node", "@types/aws-lambda", "vitest", "sst"],
+    packages: ["@types/node", "@types/aws-lambda", "vitest", "sst@^2"],
     path: "packages/functions",
     dev: true,
   }),

--- a/packages/create-sst/bin/presets/examples/nextjs-rds-drizzle/preset.mjs
+++ b/packages/create-sst/bin/presets/examples/nextjs-rds-drizzle/preset.mjs
@@ -4,7 +4,7 @@ export default [
   extend("presets/base/monorepo"),
   extract(),
   install({
-    packages: ["@types/node", "@types/aws-lambda", "vitest", "sst"],
+    packages: ["@types/node", "@types/aws-lambda", "vitest", "sst@^2"],
     path: "packages/functions",
     dev: true,
   }),


### PR DESCRIPTION
**Issue:**

When running `npx create-sst@two`, the generated project templates include dependencies that resolve to SST v3 packages instead of the intended v2 packages. This causes compatibility issues for users who want to use SST v2.

**Solution:**

This PR updates the `create-sst` templates to explicitly specify SST v2 dependencies by pinning the versions to `^2.44.0`. This ensures that `npx create-sst@two` will install the correct SST v2 packages.

**Notes:**

- This change is critical for some users who are still developing with SST v2 and are not ready to migrate to v3.

**Testing:**

- Tested locally by generating a new project with the modified `create-sst` and confirmed that the dependencies resolve to SST v2 packages.
