### PR TITLE
feat(Job): increase max timeout to 36 hours

### DIFF
--- a/.changeset/bright-lamps-smell.md
+++ b/.changeset/bright-lamps-smell.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+feat(Job): increase max timeout to 36 hours

--- a/packages/sst/src/constructs/Job.ts
+++ b/packages/sst/src/constructs/Job.ts
@@ -189,7 +189,7 @@ export interface JobProps {
    */
   memorySize?: JobMemorySize;
   /**
-   * The execution timeout. Minimum 5 minutes. Maximum 8 hours.
+   * The execution timeout. Minimum 5 minutes. Maximum 36 hours.
    *
    * @default "8 hours"
    *
@@ -785,7 +785,7 @@ export class Job extends Construct implements SSTConstruct {
 
   private normalizeTimeout(timeout: Duration): CdkDuration {
     const value = toCdkDuration(timeout);
-    if (value.toSeconds() < 5 * 60 || value.toSeconds() > 480 * 60) {
+    if (value.toSeconds() < 5 * 60 || value.toSeconds() > 2160 * 60) {
       throw new Error(`Invalid timeout value for the ${this.node.id} Job.`);
     }
     return value;


### PR DESCRIPTION
CodeBuild increased the maximum timeout from 8 hours to 36 hours on 6/28/24. The goal of this PR is to adjust the maximum timeout for Jobs accordingly.

**Announcement**
https://aws.amazon.com/about-aws/whats-new/2024/06/aws-codebuild-build-timeout-limit-increased-36-hours/