### PR TITLE
Implements a RegExp for the deploy matcher.

### DIFF
--- a/.changeset/small-pots-rule.md
+++ b/.changeset/small-pots-rule.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+cli: Implements a RegExp for the deploy matcher.

--- a/packages/sst/src/cli/commands/deploy.tsx
+++ b/packages/sst/src/cli/commands/deploy.tsx
@@ -16,7 +16,7 @@ export const deploy = (program: Program) =>
         })
         .positional("filter", {
           type: "string",
-          describe: "Optionally filter stacks to deploy",
+          describe: "Optionally filter stacks to deploy (this is a case insensitive regex)",
         }),
     async (args) => {
       const React = await import("react");
@@ -82,13 +82,16 @@ export const deploy = (program: Program) =>
         Colors.line(`   ${Colors.bold("Account:")} ${identity.Account}`);
         Colors.gap();
 
+        const filter = !!args.filter && new RegExp(args.filter, "i")
+
         const isActiveStack = (stackId: string) =>
-          !args.filter ||
-          stackId
-            .toLowerCase()
-            .replace(project.config.name.toLowerCase(), "")
-            .replace(project.config.stage.toLowerCase(), "")
-            .includes(args.filter.toLowerCase());
+          !filter ||
+          filter.test(
+            stackId
+              .toLowerCase()
+              .replace(project.config.name.toLowerCase(), "")
+              .replace(project.config.stage.toLowerCase(), "")
+          )
 
         // Generate cloud assembly
         // - if --from is specified, we will use the existing cloud assembly

--- a/packages/sst/src/cli/commands/deploy.tsx
+++ b/packages/sst/src/cli/commands/deploy.tsx
@@ -16,7 +16,7 @@ export const deploy = (program: Program) =>
         })
         .positional("filter", {
           type: "string",
-          describe: "Optionally filter stacks to deploy using a case insensitive regex",
+          describe: "Optionally filter stacks to deploy using a regex pattern",
         }),
     async (args) => {
       const React = await import("react");

--- a/packages/sst/src/cli/commands/deploy.tsx
+++ b/packages/sst/src/cli/commands/deploy.tsx
@@ -16,7 +16,7 @@ export const deploy = (program: Program) =>
         })
         .positional("filter", {
           type: "string",
-          describe: "Optionally filter stacks to deploy (this is a case insensitive regex)",
+          describe: "Optionally filter stacks to deploy using a case insensitive regex",
         }),
     async (args) => {
       const React = await import("react");

--- a/packages/sst/src/cli/commands/remove.tsx
+++ b/packages/sst/src/cli/commands/remove.tsx
@@ -7,7 +7,7 @@ export const remove = (program: Program) =>
     (yargs) =>
       yargs.option("from", { type: "string" }).positional("filter", {
         type: "string",
-        describe: "Optionally filter stacks to remove",
+        describe: "Optionally filter stacks to remove (this is a case insensitive regex)",
       }),
     async (args) => {
       const React = await import("react");
@@ -54,14 +54,16 @@ export const remove = (program: Program) =>
           });
         })();
 
+        const filter = !!args.filter && new RegExp(args.filter, "i")
         const target = assembly.stacks.filter(
           (s) =>
-            !args.filter ||
-            s.id
-              .toLowerCase()
-              .replace(project.config.name.toLowerCase(), "")
-              .replace(project.config.stage.toLowerCase(), "")
-              .includes(args.filter.toLowerCase())
+            !filter ||
+            filter.test(
+              s.id
+                .toLowerCase()
+                .replace(project.config.name.toLowerCase(), "")
+                .replace(project.config.stage.toLowerCase(), "")
+            )
         );
         if (!target.length) {
           console.log(`No stacks found matching ${blue(args.filter!)}`);

--- a/packages/sst/src/cli/commands/remove.tsx
+++ b/packages/sst/src/cli/commands/remove.tsx
@@ -7,7 +7,7 @@ export const remove = (program: Program) =>
     (yargs) =>
       yargs.option("from", { type: "string" }).positional("filter", {
         type: "string",
-        describe: "Optionally filter stacks to remove (this is a case insensitive regex)",
+        describe: "Optionally filter stacks to remove using a regex pattern",
       }),
     async (args) => {
       const React = await import("react");


### PR DESCRIPTION
This is backwards compatible as a basic string is also a valid regexp It's applied case-insensitive for the backwards compatibility.

Allows for `sst deploy "Stack1|Stack2"`

I'm not sure the appropriate way to test this?