### PR TITLE
Omit `ephemeralStorageSize` from `FunctionProps` in favor of `diskSize`

### DIFF
--- a/.changeset/silly-clocks-press.md
+++ b/.changeset/silly-clocks-press.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Omit `ephemeralStorageSize` from `FunctionProps` in favor of `diskSize

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -138,6 +138,7 @@ export interface FunctionProps
     | "layers"
     | "architecture"
     | "logRetention"
+    | "ephemeralStorageSize"
   > {
   /**
    * Used to configure additional files to copy into the function bundle


### PR DESCRIPTION
`ephemeralStorageSize` is in the `FunctionProps` by mistake because it would be overwritten by `diskSize` with the default value.