### PR TITLE
Service: expose scaling & allow default rules to be disabled

### DIFF
--- a/.changeset/tame-taxis-enjoy.md
+++ b/.changeset/tame-taxis-enjoy.md
@@ -1,0 +1,6 @@
+---
+"sst": patch
+"@sst/docs": patch
+---
+
+Service: allow default rules to be disabled

--- a/packages/sst/test/constructs/Service.test.ts
+++ b/packages/sst/test/constructs/Service.test.ts
@@ -50,6 +50,7 @@ test("default", async () => {
   expect(service.cdk?.distribution?.distributionDomainName).toBeDefined();
   expect(service.cdk?.applicationLoadBalancer).toBeDefined();
   expect(service.cdk?.certificate).toBeUndefined();
+  expect(service.cdk?.scaling).toBeDefined();
   countResources(stack, "AWS::EC2::VPC", 1);
   hasResource(stack, "AWS::EC2::VPC", {
     CidrBlock: "10.0.0.0/16",
@@ -386,6 +387,20 @@ test("scaling.cpuUtilization defined", async () => {
     }),
   });
 });
+test("scaling.cpuUtilization false", async () => {
+  const { service, stack } = await createService({
+    scaling: {
+      cpuUtilization: false,
+    },
+  });
+  countResourcesLike(stack, "AWS::ApplicationAutoScaling::ScalingPolicy", 0, {
+    TargetTrackingScalingPolicyConfiguration: objectLike({
+      PredefinedMetricSpecification: {
+        PredefinedMetricType: "ECSServiceAverageCPUUtilization",
+      },
+    }),
+  });
+});
 
 test("scaling.memoryUtilization undefined", async () => {
   const { service, stack } = await createService();
@@ -413,6 +428,20 @@ test("scaling.memoryUtilization defined", async () => {
     }),
   });
 });
+test("scaling.memoryUtilization false", async () => {
+  const { service, stack } = await createService({
+    scaling: {
+      memoryUtilization: false,
+    },
+  });
+  countResourcesLike(stack, "AWS::ApplicationAutoScaling::ScalingPolicy", 0, {
+    TargetTrackingScalingPolicyConfiguration: objectLike({
+      PredefinedMetricSpecification: {
+        PredefinedMetricType: "ECSServiceAverageMemoryUtilization",
+      },
+    }),
+  });
+});
 
 test("scaling.requestsPerContainer undefined", async () => {
   const { service, stack } = await createService();
@@ -437,6 +466,20 @@ test("scaling.requestsPerContainer defined", async () => {
         PredefinedMetricType: "ALBRequestCountPerTarget",
       }),
       TargetValue: 1000,
+    }),
+  });
+});
+test("scaling.requestsPerContainer false", async () => {
+  const { service, stack } = await createService({
+    scaling: {
+      requestsPerContainer: false,
+    },
+  });
+  countResourcesLike(stack, "AWS::ApplicationAutoScaling::ScalingPolicy", 0, {
+    TargetTrackingScalingPolicyConfiguration: objectLike({
+      PredefinedMetricSpecification: objectLike({
+        PredefinedMetricType: "ALBRequestCountPerTarget",
+      }),
     }),
   });
 });
@@ -581,6 +624,7 @@ test("cdk.cloudfrontDistribution is false", async () => {
   expect(service.cdk?.fargateService).toBeDefined();
   expect(service.cdk?.taskDefinition).toBeDefined();
   expect(service.cdk?.distribution).toBeUndefined();
+  expect(service.cdk?.scaling).toBeDefined();
 });
 test("cdk.cloudfrontDistribution is props", async () => {
   const { stack, service } = await createService({
@@ -615,6 +659,7 @@ test("cdk.applicationLoadBalancer is false", async () => {
   expect(service.cdk?.taskDefinition).toBeDefined();
   expect(service.cdk?.distribution).toBeUndefined();
   expect(service.cdk?.applicationLoadBalancer).toBeUndefined();
+  expect(service.cdk?.scaling).toBeDefined();
 });
 test("cdk.applicationLoadBalancer is props", async () => {
   const { stack, service } = await createService({

--- a/www/docs/constructs/Service.about.md
+++ b/www/docs/constructs/Service.about.md
@@ -151,6 +151,32 @@ new Service(stack, "MyService", {
 });
 ```
 
+### Applying custom auto-scaling rules
+
+Default rules can be disabled by setting values to false.
+
+Custom rules can be applied using scaling property.
+
+```js
+import { Schedule } from "aws-cdk-lib/aws-applicationautoscaling";
+
+const service = new Service(stack, "MyService", {
+  scaling: {
+    minContainers: 4,
+    maxContainers: 16,
+    cpuUtilization: false, // disable default rules
+    memoryUtilization: false,
+    requestsPerContainer: false,
+  }
+});
+
+// Starts the service at 9AM Monday to Friday
+service.cdk?.scaling.scaleOnSchedule("StartOnSchedule", {
+  schedule: Schedule.expression(`cron(0 9 ? * MON-FRI *)`),
+  minCapacity: 1,
+});
+```
+
 ---
 
 ## Custom domains

--- a/www/docs/constructs/Service.about.md
+++ b/www/docs/constructs/Service.about.md
@@ -151,32 +151,6 @@ new Service(stack, "MyService", {
 });
 ```
 
-### Applying custom auto-scaling rules
-
-Default rules can be disabled by setting values to false.
-
-Custom rules can be applied using scaling property.
-
-```js
-import { Schedule } from "aws-cdk-lib/aws-applicationautoscaling";
-
-const service = new Service(stack, "MyService", {
-  scaling: {
-    minContainers: 4,
-    maxContainers: 16,
-    cpuUtilization: false, // disable default rules
-    memoryUtilization: false,
-    requestsPerContainer: false,
-  }
-});
-
-// Starts the service at 9AM Monday to Friday
-service.cdk?.scaling.scaleOnSchedule("StartOnSchedule", {
-  schedule: Schedule.expression(`cron(0 9 ? * MON-FRI *)`),
-  minCapacity: 1,
-});
-```
-
 ---
 
 ## Custom domains
@@ -353,6 +327,33 @@ new Service(stack, "MyService", {
 ```
 
 ### Advanced examples
+
+#### Configuring Custom Scaling
+
+Here's an example of disabling the default scaling rules.
+
+```js
+const service = new Service(stack, "MyService", {
+  scaling: {
+    minContainers: 4,
+    maxContainers: 16,
+    cpuUtilization: false, // disable default rules
+    memoryUtilization: false,
+    requestsPerContainer: false,
+  }
+});
+```
+
+And add a custom rule to start the service at 9am Monday to Friday
+
+```js
+import { Schedule } from "aws-cdk-lib/aws-applicationautoscaling";
+
+service.cdk?.scaling.scaleOnSchedule("StartOnSchedule", {
+  schedule: Schedule.expression(`cron(0 9 ? * MON-FRI *)`),
+  minCapacity: 1,
+});
+```
 
 #### Configuring Fargate Service
 

--- a/www/generate.mjs
+++ b/www/generate.mjs
@@ -79,6 +79,7 @@ const CDK_DOCS_MAP = {
   HttpLambdaResponseType: "aws_apigatewayv2_authorizers",
   HttpUserPoolAuthorizer: "aws_apigatewayv2_authorizers",
   WebSocketLambdaAuthorizer: "aws_apigatewayv2_authorizers",
+  ScalableTaskCount: "aws_ecs",
   ServerlessCluster: "aws_rds",
   IServerlessCluster: "aws_rds",
   Role: "aws_iam",


### PR DESCRIPTION
Related issue: https://github.com/sst/v2/issues/6

Expose scaling as a public property so custom rules can be applied
Adding the ability to turn off the default rules when value is set to false (to avoid conflicts with custom rules).