### PR TITLE
Updating the default runtime value in SsrSiteProps type definition

### DIFF
--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -215,7 +215,7 @@ export interface SsrSiteProps {
   memorySize?: number | Size;
   /**
    * The runtime environment for the SSR function.
-   * @default nodejs18.x
+   * @default nodejs22.x
    * @example
    * ```js
    * runtime: "nodejs20.x",


### PR DESCRIPTION
As the default runtime was updated to `nodejs22.x` in [f05b1cc69c397d396cf1ad08451fe42bcb4877d6](https://github.com/sst/v2/commit/f05b1cc69c397d396cf1ad08451fe42bcb4877d6), the default runtime value should be updated in the type definition for SsrSiteProps.