### PR TITLE
Upgrade fast-jwt

### DIFF
--- a/.changeset/fair-lobsters-knock.md
+++ b/.changeset/fair-lobsters-knock.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Upgrade fast-jwt

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -79,7 +79,7 @@
     "dotenv": "^16.0.3",
     "esbuild": "0.18.13",
     "express": "^4.18.2",
-    "fast-jwt": "^3.1.1",
+    "fast-jwt": "^5.0.5",
     "get-port": "^6.1.2",
     "glob": "^10.0.0",
     "graphql": "*",


### PR DESCRIPTION
SST fails to install on node 22 due the outdated package `fast-jwt` 

https://github.com/sst/v2/issues/28