### PR TITLE
Pin adm-zip at 0.5.14

### DIFF
--- a/.changeset/tender-cats-chew.md
+++ b/.changeset/tender-cats-chew.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Pin adm-zip at 0.5.14

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -62,7 +62,7 @@
     "@babel/plugin-syntax-typescript": "^7.21.4",
     "@smithy/signature-v4": "^2.0.16",
     "@trpc/server": "9.16.0",
-    "adm-zip": "^0.5.10",
+    "adm-zip": "0.5.14",
     "aws-cdk-lib": "2.171.1",
     "aws-iot-device-sdk": "^2.2.13",
     "aws-sdk": "^2.1501.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,8 +354,8 @@ importers:
         specifier: 9.16.0
         version: 9.16.0
       adm-zip:
-        specifier: ^0.5.10
-        version: 0.5.16
+        specifier: 0.5.14
+        version: 0.5.14
       aws-cdk-lib:
         specifier: 2.171.1
         version: 2.171.1(constructs@10.3.0)
@@ -5085,8 +5085,8 @@ packages:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
 
-  adm-zip@0.5.16:
-    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+  adm-zip@0.5.14:
+    resolution: {integrity: sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==}
     engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
@@ -21292,7 +21292,7 @@ snapshots:
 
   address@1.2.2: {}
 
-  adm-zip@0.5.16: {}
+  adm-zip@0.5.14: {}
 
   agent-base@6.0.2:
     dependencies:


### PR DESCRIPTION
Pin `adm-zip` at `0.5.14` until the regression mentioned in https://github.com/cthackers/adm-zip/issues/548 has been fixed.

FIxes https://github.com/sst/v2/issues/32.