### PR TITLE
[Construct/Stack]: Custom Resource runtime update to NODEJS_22_X

### DIFF
--- a/.changeset/wet-melons-play.md
+++ b/.changeset/wet-melons-play.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Custom Resource runtime update to NODEJS_22_X

--- a/packages/sst/src/constructs/Stack.ts
+++ b/packages/sst/src/constructs/Stack.ts
@@ -236,7 +236,7 @@ export class Stack extends CDKStack {
           this.stackName + fs.readFileSync(dir + "/index.mjs").toString(),
       }),
       handler: "index.handler",
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       timeout: CDKDuration.seconds(900),
       memorySize: 1024,
     });


### PR DESCRIPTION
With the recently added `Runtime.NODEJS_22_X` in 2.47.0, I noticed that the custom resource handler was still using Node 20.

This PR just updates that to use `Runtime.NODEJS_22_x` instead of `Runtime.NODEJS_20_X`

From what I could tell all the other places runtimes are set they are using or have the option to use the latest Node runtime.