### PR TITLE
Upgrade aws-cdk-lib

### DIFF
--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -35,10 +35,10 @@
   },
   "homepage": "https://sst.dev",
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.171.1-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.177.0",
     "@aws-cdk/cloud-assembly-schema": "38.0.1",
-    "@aws-cdk/cloudformation-diff": "2.171.1",
-    "@aws-cdk/cx-api": "2.171.1",
+    "@aws-cdk/cloudformation-diff": "2.177.0",
+    "@aws-cdk/cx-api": "2.177.0",
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-cloudformation": "^3.454.0",
     "@aws-sdk/client-ecs": "^3.454.0",

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -63,7 +63,7 @@
     "@smithy/signature-v4": "^2.0.16",
     "@trpc/server": "9.16.0",
     "adm-zip": "0.5.14",
-    "aws-cdk-lib": "2.171.1",
+    "aws-cdk-lib": "2.177.0",
     "aws-iot-device-sdk": "^2.2.13",
     "aws-sdk": "^2.1501.0",
     "builtin-modules": "3.2.0",


### PR DESCRIPTION
Upgrade `aws-cdk-lib` to `2.177.0`, the latest version available.