### PR TITLE
[SST]: Ensure error name is correct when using local lambda dev mode

### DIFF
--- a/.changeset/afraid-frogs-accept.md
+++ b/.changeset/afraid-frogs-accept.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Ensure error name is correct when using local lambda dev mode

--- a/packages/sst/support/bridge/live-lambda.ts
+++ b/packages/sst/support/bridge/live-lambda.ts
@@ -170,6 +170,7 @@ export async function handler(event: any, context: any) {
 
   if (result.type === "function.error") {
     const error = new Error(result.properties.errorMessage);
+    error.name = result.properties.errorType;
     error.stack = result.properties.trace?.join("\n");
     throw error;
   }

--- a/packages/sst/support/nodejs-runtime/index.ts
+++ b/packages/sst/support/nodejs-runtime/index.ts
@@ -98,7 +98,7 @@ async function error(ex: any) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      errorType: "Error",
+      errorType: ex.name ?? "Error",
       errorMessage: ex.message,
       trace: ex.stack?.split("\n"),
     }),


### PR DESCRIPTION
As discussed in https://github.com/sst/sst/issues/4747#issuecomment-2640218667, this PR ensures that the correct name of the error is thrown during live local lambda dev.