### PR TITLE
Ensure SSO region is not overridden by the client region

### DIFF
--- a/.changeset/three-cows-hammer.md
+++ b/.changeset/three-cows-hammer.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Ensure SSO region is not overridden by the client region

--- a/packages/sst/src/credentials.ts
+++ b/packages/sst/src/credentials.ts
@@ -14,7 +14,7 @@ export const useAWSCredentialsProvider = lazy(() => {
   const project = useProject();
   Logger.debug("Using AWS profile", project.config.profile);
   const provider = fromNodeProviderChain({
-    clientConfig: { region: project.config.region },
+    parentClientConfig: { region: project.config.region },
     profile: project.config.profile,
     roleArn: project.config.role,
     mfaCodeProvider: async (serialArn: string) => {


### PR DESCRIPTION
Passing the region in the `clientConfig` parameter is causing the SSO authentication logic to send the SSO request to this region instead of to the `sso_region` configured in the ~/.aws/config file. The `parentClientConfig` parameter has a lower precedence, which prevents it from overriding the configured SSO region.

Resolves: #44 