### PR TITLE
fix(sst): handle escape characters in query keys

### DIFF
--- a/.changeset/fast-jeans-explode.md
+++ b/.changeset/fast-jeans-explode.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+handle keys in query string with escaped characters

--- a/packages/sst/support/signing-function/helpers/queryStringToQueryParameterBag.ts
+++ b/packages/sst/support/signing-function/helpers/queryStringToQueryParameterBag.ts
@@ -3,31 +3,24 @@ import { QueryParameterBag } from "@aws-sdk/types";
 export const queryStringToQueryParameterBag = (
   queryString: string
 ): QueryParameterBag => {
+  if (!queryString) {
+    return {};
+  }
+
   const query: QueryParameterBag = {};
+  const searchParams = new URLSearchParams(queryString);
+  
+  for (const [key, value] of searchParams.entries()) {
+    const decodedKey = decodeURIComponent(key);
+    const decodedValue = decodeURIComponent(value);
 
-  const kvPairs = queryString.split("&").filter((v) => v);
-
-  for (const kvPair of kvPairs) {
-    const split = kvPair.split("=") as [string, string?];
-
-    const key = split[0];
-    const value = split[1];
-
-    if (query[key] === undefined || query[key] === null) {
-      query[key] = value ? decodeURIComponent(value) : "";
-      continue;
+    if (query[decodedKey] === undefined) {
+      query[decodedKey] = decodedValue;
+    } else if (Array.isArray(query[decodedKey])) {
+      (query[decodedKey] as string[]).push(decodedValue);
+    } else {
+      query[decodedKey] = [query[decodedKey] as string, decodedValue];
     }
-
-    if (value === undefined || value === "") {
-      continue;
-    }
-
-    if (Array.isArray(query[key])) {
-      (query[key] as string[]).push(decodeURIComponent(value));
-      continue;
-    }
-
-    query[key] = [query[key] as string, decodeURIComponent(value)];
   }
 
   return query;


### PR DESCRIPTION
SST didn't correctly sign a url where the query keys had escape characters. For example https://www.example.com/test%3A=1

It only handled them in values.

Got AI to rewrite this code, and working perfectly for me.