### PR TITLE
Allow passing in EventBridgeClient to createEventBuilder

### DIFF
--- a/packages/sst/src/node/event-bus/index.ts
+++ b/packages/sst/src/node/event-bus/index.ts
@@ -42,8 +42,9 @@ export function createEventBuilder<
   metadata?: MetadataSchema;
   metadataFn?: MetadataFunction;
   validator: Validator;
+  client?: EventBridgeClient;
 }) {
-  const client = new EventBridgeClient({});
+  const client = input.client || new EventBridgeClient({});
   const validator = input.validator;
   const metadataValidator = input.metadata ? validator(input.metadata) : null;
   return function event<


### PR DESCRIPTION
Use case: I want to emit a lot of events in parallel so I'd like to be able to [set maxSockets](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html)

