### PR TITLE
Fix Error in get_remaining_time_in_millis

### DIFF
--- a/packages/sst/support/python-runtime/runtime.py
+++ b/packages/sst/support/python-runtime/runtime.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     context = Context(
         r.getheader('Lambda-Runtime-Invoked-Function-Arn'),
         r.getheader('Lambda-Runtime-Aws-Request-Id'),
-        r.getheader('Lambda-Runtime-Deadline-Ms'),
+        int(r.getheader('Lambda-Runtime-Deadline-Ms')),
         r.getheader('Lambda-Runtime-Cognito-Identity'),
         r.getheader('Lambda-Runtime-Client-Context'),
         r.getheader('Lambda-Runtime-Log-Group-Name'),


### PR DESCRIPTION
Fix Error: unsupported operand type(s) for -: 'str' and 'int'

Currently calls to this function give:
Error: unsupported operand type(s) for -: 'str' and 'int'
     File "/Users/dramus/chartflow/node_modules/sst/support/python-runtime/runtime.py", line 101, in <module>
    result = handler(event, context)

     File "/Users/dramus/.virtualenvs/chartflow/lib/python3.13/site-packages/datadog_lambda/wrapper.py", line 239, in __call__
    """Executes when the wrapped function gets called"""

     File "/Users/dramus/.virtualenvs/chartflow/lib/python3.13/site-packages/ddtrace/contrib/internal/aws_lambda/patch.py", line 117, in __call__
    self._before(args, kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^

     File "/Users/dramus/.virtualenvs/chartflow/lib/python3.13/site-packages/ddtrace/contrib/internal/aws_lambda/patch.py", line 145, in _before
    self.timeoutChannel._start()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^

     File "/Users/dramus/.virtualenvs/chartflow/lib/python3.13/site-packages/ddtrace/contrib/internal/aws_lambda/patch.py", line 74, in _start
    remaining_time_in_millis = self.context.get_remaining_time_in_millis()

     File "/Users/dramus/chartflow/node_modules/sst/support/python-runtime/runtime.py", line 38, in get_remaining_time_in_millis
    return int(max(self.deadline_ms - int(round(time() * 1000)), 0))
                   ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
