### PR TITLE
Add support for custom CloudFront origin request policies

### DIFF
--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -459,6 +459,12 @@ export interface SsrSiteProps {
      * from the server rendering Lambda.
      */
     responseHeadersPolicy?: IResponseHeadersPolicy;
+
+    /**
+     * Override the CloudFront origin request policy properties for responses
+     * from the server rendering Lambda.
+     */
+    originRequestPolicy?: IOriginRequestPolicy;
     /**
      * Override the CloudFront viewer protocol policy properties.
      * @default ViewerProtocolPolicy.REDIRECT_TO_HTTPS
@@ -878,6 +884,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
           compress: true,
           cachePolicy: CachePolicy.CACHING_OPTIMIZED,
           responseHeadersPolicy: cdk?.responseHeadersPolicy,
+          originRequestPolicy: cdk?.originRequestPolicy,
           functionAssociations: cfFunction
             ? [
                 {


### PR DESCRIPTION
This update introduces the ability to override CloudFront origin request policy properties for SSR sites.

It seems that is impossible to set the Origin Request Policy for the behaviours using staticServer origin.
With this small modification, is it possible to handle S3 Cors needs, using transform in this way

```
                cdk: {                    
                    originRequestPolicy: OriginRequestPolicy.CORS_S3_ORIGIN,
```