### PR TITLE
use tag 'two' instead of 'latest' in sst update

### DIFF
--- a/.changeset/dry-readers-marry.md
+++ b/.changeset/dry-readers-marry.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+use tag 'two' instead of 'latest' in sst update

--- a/packages/sst/src/cli/commands/update.ts
+++ b/packages/sst/src/cli/commands/update.ts
@@ -26,7 +26,7 @@ export const update = (program: Program) =>
         const project = useProject();
         const files = await findAllPackageJson(project.paths.root);
         const metadata = await fetch(
-          `https://registry.npmjs.org/sst/${args.version || "latest"}`
+          `https://registry.npmjs.org/sst/${args.version || "two"}`
         ).then((resp) => resp.json() as any);
         const allChanges = new Map<string, Packages>();
         const allOldPackages = new Map<string, Packages>();


### PR DESCRIPTION
Hello, I was also affected by #55 and decided to file a PR.

One thing this does not solve is the update of other packages such as astro-sst, I noticed they have versions tagged with '@two', but sst update does not currently support the update of external updates.

We can maintain a constant with external packages then make a query to the registry and get the latest version of @two tag.

If we're going down that path, are there any other packages like astro-sst that need to be updated by sst update?