### PR TITLE
fix: use sso region instead of client region

### DIFF
--- a/packages/sst/src/credentials.ts
+++ b/packages/sst/src/credentials.ts
@@ -16,7 +16,7 @@ export const useAWSCredentialsProvider: () => AwsCredentialIdentityProvider =
     const project = useProject();
     Logger.debug("Using AWS profile", project.config.profile);
     const provider = fromNodeProviderChain({
-      clientConfig: { region: project.config.region },
+      parentClientConfig: { region: project.config.region },
       profile: project.config.profile,
       roleArn: project.config.role,
       mfaCodeProvider: async (serialArn: string) => {


### PR DESCRIPTION
Fixes the same issue as #46 

"_Passing the region in the clientConfig parameter is causing the SSO authentication logic to send the SSO request to this region instead of to the sso_region configured in the ~/.aws/config file. The parentClientConfig parameter has a lower precedence, which prevents it from overriding the configured SSO region._"