### PR TITLE
Passing deploy role to stack params

### DIFF
--- a/.changeset/crazy-cobras-act.md
+++ b/.changeset/crazy-cobras-act.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Passing deploy role to stack params

--- a/packages/sst/src/stacks/deploy.ts
+++ b/packages/sst/src/stacks/deploy.ts
@@ -297,16 +297,16 @@ async function buildCloudFormationStackParams(
   deployment: any,
   stack: CloudFormationStackArtifact
 ) {
-  const resolvedEnv = await deployment.resolveEnvironment(stack);
-  const executionRoleArn = stack.cloudFormationExecutionRoleArn?.replace("${AWS::AccountId}", resolvedEnv.account);
+  const env = await deployment.envs.accessStackForMutableStackOperations(stack);
+  const executionRoleArn = await env.replacePlaceholders(stack.cloudFormationExecutionRoleArn);
   const s3Url = stack
     .stackTemplateAssetObjectUrl!.replace(
       "${AWS::AccountId}",
-      resolvedEnv.account
+      env.resolvedEnvironment.account
     )
     .match(/s3:\/\/([^/]+)\/(.*)$/);
   const templateUrl = s3Url
-    ? `https://s3.${resolvedEnv.region}.amazonaws.com/${s3Url[1]}/${s3Url[2]}`
+    ? `https://s3.${env.resolvedEnvironment.region}.amazonaws.com/${s3Url[1]}/${s3Url[2]}`
     : stack.stackTemplateAssetObjectUrl;
 
   return {

--- a/packages/sst/src/stacks/deploy.ts
+++ b/packages/sst/src/stacks/deploy.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { useBus } from "../bus.js";
-import { useProject } from "../project.js";
+import { ConfigOptions, useProject } from "../project.js";
 import { useAWSClient, useAWSProvider } from "../credentials.js";
 import { Logger } from "../logger.js";
 import { type CloudFormationStackArtifact } from "aws-cdk-lib/cx-api";
@@ -15,6 +15,7 @@ import { VisibleError } from "../error.js";
 
 export async function publishAssets(stacks: CloudFormationStackArtifact[]) {
   Logger.debug("Publishing assets");
+  const { cdk } = useProject().config;
 
   const results: Record<string, any> = {};
   for (const stackArtifact of stacks) {
@@ -24,7 +25,7 @@ export async function publishAssets(stacks: CloudFormationStackArtifact[]) {
     await buildAndPublishAssets(deployment, stackArtifact);
     results[stackArtifact.stackName] = {
       isUpdate: cfnStack && cfnStack.StackStatus !== "REVIEW_IN_PROGRESS",
-      params: await buildCloudFormationStackParams(deployment, stackArtifact),
+      params: await buildCloudFormationStackParams(deployment, stackArtifact, cdk),
     };
   }
   return results;
@@ -120,7 +121,7 @@ export async function deploy(
       await deleteCloudFormationStack(stack.stackName);
     }
 
-    const stackParams = await buildCloudFormationStackParams(deployment, stack);
+    const stackParams = await buildCloudFormationStackParams(deployment, stack, cdk);
     try {
       cfnStack && cfnStack.StackStatus !== "REVIEW_IN_PROGRESS"
         ? await updateCloudFormationStack(stackParams)
@@ -295,10 +296,11 @@ async function buildAndPublishAssets(
 
 async function buildCloudFormationStackParams(
   deployment: any,
-  stack: CloudFormationStackArtifact
+  stack: CloudFormationStackArtifact,
+  cdkOptions?: ConfigOptions["cdk"]
 ) {
   const env = await deployment.envs.accessStackForMutableStackOperations(stack);
-  const executionRoleArn = await env.replacePlaceholders(stack.cloudFormationExecutionRoleArn);
+  const executionRoleArn = cdkOptions?.cloudFormationExecutionRole ?? await env.replacePlaceholders(stack.cloudFormationExecutionRoleArn);
   const s3Url = stack
     .stackTemplateAssetObjectUrl!.replace(
       "${AWS::AccountId}",

--- a/packages/sst/src/stacks/deploy.ts
+++ b/packages/sst/src/stacks/deploy.ts
@@ -298,6 +298,7 @@ async function buildCloudFormationStackParams(
   stack: CloudFormationStackArtifact
 ) {
   const resolvedEnv = await deployment.resolveEnvironment(stack);
+  const executionRoleArn = stack.cloudFormationExecutionRoleArn?.replace("${AWS::AccountId}", resolvedEnv.account);
   const s3Url = stack
     .stackTemplateAssetObjectUrl!.replace(
       "${AWS::AccountId}",
@@ -311,6 +312,7 @@ async function buildCloudFormationStackParams(
   return {
     StackName: stack.stackName,
     TemplateURL: templateUrl,
+    RoleARN: executionRoleArn,
     //TemplateBody: bodyParameter.TemplateBody,
     //Parameters: stackParams.apiParameters,
     Parameters: [],


### PR DESCRIPTION
I found that cdk deploy role aren't being used for deployment, resulted in unnecessary permissions needed for deplooyment.
https://github.com/sst/v2/issues/82#issuecomment-3017784682

The easiest option to fix it seems to be passing cdk deploy role to CloudFormation stack params.

However, might need to look into using @aws-cdk/toolkit-lib to handle deployment if possible.

