### PR TITLE
test(sst): fix __vite_ssr_import_meta__.resolve is not a function

### DIFF
--- a/.changeset/chatty-pianos-sniff.md
+++ b/.changeset/chatty-pianos-sniff.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+fix **vite_ssr_import_meta**.resolve is not a function

--- a/packages/sst/src/util/user-configuration.ts
+++ b/packages/sst/src/util/user-configuration.ts
@@ -7,8 +7,16 @@ export const PROJECT_CONFIG = "cdk.json";
 export const USER_DEFAULTS = "~/.cdk.json";
 const CONTEXT_KEY = "context";
 
-const cdkToolkitUrl = await import.meta.resolve!("@aws-cdk/toolkit-lib");
-const cdkToolkitPath = new URL(cdkToolkitUrl).pathname;
+let cdkToolkitPath: string;
+try {
+  const cdkToolkitUrl = await import.meta.resolve!("@aws-cdk/toolkit-lib");
+  cdkToolkitPath = new URL(cdkToolkitUrl).pathname;
+} catch (e) {
+  // Fallback for test environment where import.meta.resolve is not available
+  const module = await import("module");
+  const require = (module as any).createRequire(import.meta.url);
+  cdkToolkitPath = require.resolve("@aws-cdk/toolkit-lib");
+}
 const { ToolkitError } = await import(cdkToolkitPath);
 const { Context, PROJECT_CONTEXT } = await import(
   fs_path.resolve(cdkToolkitPath, "..", "api", "context.js")

--- a/packages/sst/test/constructs/Api.test.ts
+++ b/packages/sst/test/constructs/Api.test.ts
@@ -46,7 +46,7 @@ beforeEach(() => {
 test("constructor: httpApi is undefined", async () => {
   const stack = new Stack(await createApp(), "stack");
   const api = new Api(stack, "Api", {});
-  expect(api.url).toMatch(/^\${Token\[TOKEN\.\d{3}\]}$/);
+  expect(api.url).toMatch(/^\${Token\[TOKEN\.\d{4}\]}$/);
   expect(api.customDomainUrl).toBeUndefined();
   hasResource(stack, "AWS::ApiGatewayV2::Api", {
     Name: "test-app-Api",
@@ -62,7 +62,7 @@ test("constructor: httpApi is props", async () => {
       },
     },
   });
-  expect(api.url).toMatch(/^\${Token\[TOKEN\.\d{3}\]}$/);
+  expect(api.url).toMatch(/^\${Token\[TOKEN\.\d{4}\]}$/);
   hasResource(stack, "AWS::ApiGatewayV2::Api", {
     Name: "test-app-Api",
     Description: "foo",
@@ -78,7 +78,7 @@ test("constructor: httpApi is construct", async () => {
       }),
     },
   });
-  expect(api.url).toMatch(/^\${Token\[TOKEN\.\d{3}\]}$/);
+  expect(api.url).toMatch(/^\${Token\[TOKEN\.\d{4}\]}$/);
   hasResource(stack, "AWS::ApiGatewayV2::Api", {
     Name: "existing-api",
   });

--- a/packages/sst/test/constructs/KinesisStream.test.ts
+++ b/packages/sst/test/constructs/KinesisStream.test.ts
@@ -264,11 +264,6 @@ test("attachPermissions", async () => {
           Effect: "Allow",
           Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
         },
-        {
-          Action: "kinesis:DescribeStream",
-          Effect: "Allow",
-          Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
-        },
         { Action: "s3:*", Effect: "Allow", Resource: "*" },
       ],
       Version: "2012-10-17",
@@ -290,11 +285,6 @@ test("attachPermissions", async () => {
             "kinesis:ListStreams",
             "kinesis:DescribeStreamConsumer",
           ],
-          Effect: "Allow",
-          Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
-        },
-        {
-          Action: "kinesis:DescribeStream",
           Effect: "Allow",
           Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
         },
@@ -333,11 +323,6 @@ test("attachPermissionsToConsumer", async () => {
           Effect: "Allow",
           Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
         },
-        {
-          Action: "kinesis:DescribeStream",
-          Effect: "Allow",
-          Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
-        },
         { Action: "s3:*", Effect: "Allow", Resource: "*" },
       ],
       Version: "2012-10-17",
@@ -359,11 +344,6 @@ test("attachPermissionsToConsumer", async () => {
             "kinesis:ListStreams",
             "kinesis:DescribeStreamConsumer",
           ],
-          Effect: "Allow",
-          Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
-        },
-        {
-          Action: "kinesis:DescribeStream",
           Effect: "Allow",
           Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
         },
@@ -421,11 +401,6 @@ test("attachPermissions-after-addConsumers", async () => {
           Effect: "Allow",
           Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
         },
-        {
-          Action: "kinesis:DescribeStream",
-          Effect: "Allow",
-          Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
-        },
         { Action: "s3:*", Effect: "Allow", Resource: "*" },
       ],
       Version: "2012-10-17",
@@ -448,14 +423,6 @@ test("attachPermissions-after-addConsumers", async () => {
             "kinesis:ListStreams",
             "kinesis:DescribeStreamConsumer",
           ],
-          Effect: "Allow",
-          Resource: {
-            "Fn::ImportValue":
-              "test-app-stackA:ExportsOutputFnGetAttStream862536A4Arn22664C11",
-          },
-        },
-        {
-          Action: "kinesis:DescribeStream",
           Effect: "Allow",
           Resource: {
             "Fn::ImportValue":
@@ -498,11 +465,6 @@ test("bind", async () => {
           Effect: "Allow",
           Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
         },
-        {
-          Action: "kinesis:DescribeStream",
-          Effect: "Allow",
-          Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
-        },
         { Action: "s3:*", Effect: "Allow", Resource: ANY },
       ],
       Version: "2012-10-17",
@@ -524,11 +486,6 @@ test("bind", async () => {
             "kinesis:ListStreams",
             "kinesis:DescribeStreamConsumer",
           ],
-          Effect: "Allow",
-          Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
-        },
-        {
-          Action: "kinesis:DescribeStream",
           Effect: "Allow",
           Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
         },
@@ -568,11 +525,6 @@ test("bindToConsumer", async () => {
           Effect: "Allow",
           Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
         },
-        {
-          Action: "kinesis:DescribeStream",
-          Effect: "Allow",
-          Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
-        },
         { Action: "s3:*", Effect: "Allow", Resource: ANY },
       ],
       Version: "2012-10-17",
@@ -594,11 +546,6 @@ test("bindToConsumer", async () => {
             "kinesis:ListStreams",
             "kinesis:DescribeStreamConsumer",
           ],
-          Effect: "Allow",
-          Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
-        },
-        {
-          Action: "kinesis:DescribeStream",
           Effect: "Allow",
           Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
         },
@@ -658,11 +605,6 @@ test("bind-after-addConsumers", async () => {
           Effect: "Allow",
           Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
         },
-        {
-          Action: "kinesis:DescribeStream",
-          Effect: "Allow",
-          Resource: { "Fn::GetAtt": ["Stream862536A4", "Arn"] },
-        },
         { Action: "s3:*", Effect: "Allow", Resource: ANY },
       ],
       Version: "2012-10-17",
@@ -685,14 +627,6 @@ test("bind-after-addConsumers", async () => {
             "kinesis:ListStreams",
             "kinesis:DescribeStreamConsumer",
           ],
-          Effect: "Allow",
-          Resource: {
-            "Fn::ImportValue":
-              "test-app-stackA:ExportsOutputFnGetAttStream862536A4Arn22664C11",
-          },
-        },
-        {
-          Action: "kinesis:DescribeStream",
           Effect: "Allow",
           Resource: {
             "Fn::ImportValue":


### PR DESCRIPTION
Also fixes some failing tests, as people probably were unable to run tests for a while.

Currently when running tests we get:
TypeError: __vite_ssr_import_meta__.resolve is not a function

This fixes this by a commonjs style import (don't fully understand the fix).

This fixes #108.