### PR TITLE
Fallback to package version from optional deps

### DIFF
--- a/packages/sst/src/runtime/handlers/node.ts
+++ b/packages/sst/src/runtime/handlers/node.ts
@@ -251,7 +251,7 @@ export const useNodeHandler = (): RuntimeHandler => {
             path.join(input.out, "package.json"),
             JSON.stringify({
               dependencies: Object.fromEntries(
-                installPackages.map((x) => [x, json.dependencies?.[x] || "*"])
+                installPackages.map((x) => [x, json.dependencies?.[x] || json.optionalDependencies?.[x] || "*"])
               ),
             })
           );


### PR DESCRIPTION
We're attempting to install `@duckdb/node-bindings@1.4.1-r.4`, which has the various os/arch flavors listed as optional dependencies.

We need it to install `@duckdb/node-bindings-linux-arm64@1.4.1-r.4`, but can't add that to our project's dependencies without it throwing a big error when we attempt to run `pnpm install` on our non-linux dev machines.

By falling back to reading from the optionalDependencies, we can list `@duckdb/node-bindings-linux-arm64@1.4.1-r.4` in our `optionalDependencies` and have SST install that specific version at deploy time instead of defaulting to `*` (the latest version) like it does now.
