### PR TITLE
Packages: Bump esbuild from v0.18 to latest (v0.27.2)

### DIFF
--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -78,7 +78,7 @@
     "cross-spawn": "^7.0.3",
     "dendriform-immer-patch-optimiser": "^2.1.0",
     "dotenv": "^16.0.3",
-    "esbuild": "0.27.2",
+    "esbuild": "^0.27.2",
     "express": "^4.18.2",
     "fast-jwt": "^5.0.5",
     "get-port": "^6.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,7 +402,7 @@ importers:
         specifier: ^16.0.3
         version: 16.5.0
       esbuild:
-        specifier: 0.27.2
+        specifier: ^0.27.2
         version: 0.27.2
       express:
         specifier: ^4.18.2


### PR DESCRIPTION
Upgrades the esbuild dependency to the latest stable version (v0.27.2).

Motivation is to [patch CWE-346](https://github.com/evanw/esbuild/security/advisories/GHSA-67mh-4wv8-2f99). 

Additional changes are unlikely to be necessary based on the esbuild release notes ([2025](https://github.com/evanw/esbuild/blob/main/CHANGELOG.md) | [2024](https://github.com/evanw/esbuild/blob/main/CHANGELOG-2024.md) | [2023](https://github.com/evanw/esbuild/blob/main/CHANGELOG-2023.md))

Usage of esbuild APIs should be be backwards compatible and it's been common for users to add pnpm overrides for esbuild for years now (including my own projects).