### PR TITLE
Bump fast-jwt for security fixes

### DIFF
--- a/packages/sst/dist/package.json
+++ b/packages/sst/dist/package.json
@@ -74,7 +74,7 @@
     "dotenv": "^16.0.3",
     "esbuild": "0.18.13",
     "express": "^4.18.2",
-    "fast-jwt": "^3.1.1",
+    "fast-jwt": "^6.2.0",
     "get-port": "^6.1.2",
     "glob": "^10.0.0",
     "graphql": "*",

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -80,7 +80,7 @@
     "dotenv": "^16.0.3",
     "esbuild": "0.18.13",
     "express": "^4.18.2",
-    "fast-jwt": "^5.0.5",
+    "fast-jwt": "^6.2.0",
     "get-port": "^6.1.2",
     "glob": "^10.0.0",
     "graphql": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,8 +408,8 @@ importers:
         specifier: ^4.18.2
         version: 4.21.2
       fast-jwt:
-        specifier: ^5.0.5
-        version: 5.0.6
+        specifier: ^6.2.0
+        version: 6.2.0
       get-port:
         specifier: ^6.1.2
         version: 6.1.2
@@ -6481,8 +6481,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-jwt@5.0.6:
-    resolution: {integrity: sha512-LPE7OCGUl11q3ZgW681cEU2d0d2JZ37hhJAmetCgNyW8waVaJVZXhyFF6U2so1Iim58Yc7pfxJe2P7MNetQH2g==}
+  fast-jwt@6.2.0:
+    resolution: {integrity: sha512-8HzL09abkCBIaZZSOhDP8re1ozSWa6297so2u46IbeE4zznVEbYX/WrlnZP8K9GCr7gT5uT1uMvOSNZAY86DBQ==}
     engines: {node: '>=20'}
 
   fast-querystring@1.1.2:
@@ -9888,10 +9888,12 @@ packages:
   tar@4.4.19:
     resolution: {integrity: sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==}
     engines: {node: '>=4.5'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -21080,7 +21082,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-jwt@5.0.6:
+  fast-jwt@6.2.0:
     dependencies:
       '@lukeed/ms': 2.0.2
       asn1.js: 5.4.1


### PR DESCRIPTION
There are a few CVEs for fast-jwt. Bumping to resolved versions here. Let me know if there is any further testing I can perform to help verify. We've been using sst with fast-jwt overridden to this version already. 