### PR TITLE
Isolate sst dev and sst bind synth assembly dirs to prevent placeholder template deploys

### DIFF
--- a/packages/sst/src/cli/commands/bind.ts
+++ b/packages/sst/src/cli/commands/bind.ts
@@ -150,6 +150,7 @@ export const bind = (program: Program) =>
             await Stacks.synth({
               fn: sstConfig.stacks,
               mode: "remove",
+              buildDir: `.sst/bind`,
             });
           }
 

--- a/packages/sst/src/cli/commands/dev.tsx
+++ b/packages/sst/src/cli/commands/dev.tsx
@@ -222,7 +222,7 @@ export const dev = (program: Program) =>
                 increaseTimeout: args["increase-timeout"],
                 scriptVersion,
                 fn: project.stacks,
-                outDir: `.sst/cdk.out`,
+                buildDir: `.sst/cdk.out`,
                 mode: "dev",
               });
 

--- a/packages/sst/src/stacks/synth.ts
+++ b/packages/sst/src/stacks/synth.ts
@@ -10,7 +10,6 @@ import { Configuration } from "../util/user-configuration.js";
 
 interface SynthOptions {
   buildDir?: string;
-  outDir?: string;
   increaseTimeout?: boolean;
   scriptVersion?: string;
   mode: App["mode"];


### PR DESCRIPTION
Fixes #139.

`sst dev` passed `outDir` to `Stacks.synth()`, which only reads `buildDir`, so dev synthesized and deployed from the shared `.sst/dist` — the same dir `sst bind` re-synthesizes in `mode: "remove"` (all functions = inline placeholder stubs). Because template assets are content-addressed at synth time but read at publish time, and existing keys are never re-uploaded, a bind synth landing mid-deploy uploads placeholder bytes under the real template's hash and permanently breaks the stack (every dev deploy replays the poison; CFN says "no changes"). Details and full forensic walkthrough in the linked issue.

Changes:
- `dev.tsx`: `outDir` → `buildDir` (`.sst/cdk.out`) — honors the original intent, giving dev a private assembly dir.
- `bind.ts`: bind synthesizes into `.sst/bind` so its remove-mode placeholder templates can never sit where a deployer reads.
- `synth.ts`: remove the dead `outDir?: string` from `SynthOptions` so the mistake can't silently recur.

`tsc --noEmit` clean in `packages/sst`. We've been running this exact change as a pnpm patch against sst 2.49.8; verified `sst dev`, `sst bind`, and `sst types` all work, dev deploys from `.sst/cdk.out`, and bind no longer touches `.sst/dist`.

Suggested label: `bug`.

Disclosure: this fix was diagnosed and prepared with AI assistance (Claude Code); the change was human-reviewed and verified end-to-end against a real app before submission.